### PR TITLE
Heroku HTTPS log drain -> fluentd -> DataDog

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'http://rubygems.org'
+
+# ruby '>= 2.3.1', '< 2.6'
+
+gem 'fluentd', '~> 1.2.2'
+gem 'fluent-plugin-datadog', '~> 0.10.3'
+gem 'fluent-plugin-heroku-http', '~> 0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,42 @@
+GEM
+  remote: http://rubygems.org/
+  specs:
+    cool.io (1.5.3)
+    dig_rb (1.0.1)
+    fluent-plugin-datadog (0.10.4)
+    fluent-plugin-heroku-http (0.0.1)
+      fluentd (>= 1.0)
+    fluentd (1.2.6)
+      cool.io (>= 1.4.5, < 2.0.0)
+      dig_rb (~> 1.0.0)
+      http_parser.rb (>= 0.5.1, < 0.7.0)
+      msgpack (>= 0.7.0, < 2.0.0)
+      serverengine (>= 2.0.4, < 3.0.0)
+      sigdump (~> 0.2.2)
+      strptime (>= 0.2.2, < 1.0.0)
+      tzinfo (~> 1.0)
+      tzinfo-data (~> 1.0)
+      yajl-ruby (~> 1.0)
+    http_parser.rb (0.6.0)
+    msgpack (1.2.4)
+    serverengine (2.0.7)
+      sigdump (~> 0.2.2)
+    sigdump (0.2.4)
+    strptime (0.2.3)
+    thread_safe (0.3.6)
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
+    tzinfo-data (1.2018.5)
+      tzinfo (>= 1.0.0)
+    yajl-ruby (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fluent-plugin-datadog (~> 0.10.3)
+  fluent-plugin-heroku-http (~> 0.0.1)
+  fluentd (~> 1.2.2)
+
+BUNDLED WITH
+   1.16.1

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Applause
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec fluentd --use-v1-config -c fluent.conf -i "<source>\n @type heroku_http\n port $PORT\n</source>"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
 # heroku-fluentd-datadog
+
+This is a [Heroku](https://heroku.com) application which contains everything
+to run [fluentd](https://fluentd.org) on Heroku to accept logs from [HTTPS
+drains](https://devcenter.heroku.com/articles/log-drains#https-drains) using
+the [in_heroku_http](https://github.com/ApplauseOSS/fluent-plugin-heroku-http)
+plugin to fluentd. The
+[filter_record_transformer](https://docs.fluentd.org/v1.0/articles/filter_record_transformer)
+plugin is used to inject the source application's hostname, service name,
+and fluent tag into the record. The
+[out_datadog](https://github.com/DataDog/fluent-plugin-datadog) plugin is
+used to stream the records to DataDog Logging.
+
+This application uses the request PATH to specify the fluentd tag to use for
+routing. This matches the behavior of the
+[in_http](https://docs.fluentd.org/v1.0/articles/in_http) plugin. The value
+of the `hostname` attribute of the record can be set by specifying the
+desired value as the second (or more) part of the tag, using a `.`
+separator, with `.herokuapp.com` automatically appended to the value. To set
+the hostname to `my-example-app.herokuapp.com` and route to DataDog, you
+would send requests to `/datadog.my-example-app` of this application.
+
+## Setup
+
+Check out this repository and create a Heroku application from it.
+```
+# Login to Heroku, then create
+$ heroku apps:create YOUR-LOGGING-APP-NAME
+
+# Next, configure your API key
+$ heroku config:set DD_API_KEY=YOUR-DATADOG-API-KEY -a YOUR-LOGGING-APP-NAME
+
+# Push your application
+$ git push heroku master
+```
+
+Next, you configure Heroku HTTPS log drains to publish logs to this
+application.
+
+```
+$ heroku drains:add https://YOUR-LOGGING-APP-NAME/datadog.YOUR-SOURCE-APP-NAME -a YOUR-SOURCE-APP-NAME
+```
+
+Logs should now be flowing from your service to DataDog.
+
+## Testing
+
+This application supports sending incoming events to STDOUT using a `debug`
+tag prefix.
+```
+# debug using curl
+$ curl "https://YOUR-LOGGING-APP-NAME/debug.YOUR-SOURCE-APP-NAME" -d "60 <13>1 2014-01-29T06:25:52.589365+00:00 host app web.1 - foo"
+```
+
+This should show up in the logging application's logs on Heroku.

--- a/conf.d/filter_tag.conf
+++ b/conf.d/filter_tag.conf
@@ -1,0 +1,11 @@
+## match tag=datadog.** and add hostname, service, and tag
+<filter datadog.**>
+  @type record_transformer
+  enable_ruby true
+  auto_typecast true
+  <record>
+    hostname ${if record['host']; record['host']; elsif tag_parts[1]; "#{tag_parts[1]}.herokuapp.com"; else 'herokuapp.com'; end}
+    service ${if record['ident'] && record['pid']; "#{record['ident']}[#{record['pid']}]"; else 'app[web.1]'; end}
+    tag ${tag}
+  </record>
+</filter>

--- a/conf.d/match_datadog.conf
+++ b/conf.d/match_datadog.conf
@@ -1,0 +1,24 @@
+## match tag=datadog.** and write to datadog
+<match datadog.**>
+  @type datadog
+  api_key "#{ENV['DD_API_KEY']}"
+  use_ssl true
+  dd_source "#{ENV['DD_LOG_SOURCE'] || 'heroku'}"
+  dd_sourcecategory "#{ENV['DD_LOG_SOURCECATEGORY'] || 'fluentd'}"
+  dd_tags "#{ENV['DD_TAGS'] || 'source:fluentd' }"
+  <buffer>
+    @type file
+    path ./buffer/datadog
+    flush_at_shutdown true
+    flush_interval 10s
+    flush_mode interval
+    retry_forever true
+  </buffer>
+  <inject>
+    hostname_key hostname
+    tag_key tag
+    time_key time
+    time_type string
+    localtime false
+  </inject>
+</match>

--- a/fluent.conf
+++ b/fluent.conf
@@ -1,0 +1,6 @@
+@include ./conf.d/*.conf
+
+## match tag=debug.** and dump to console
+<match debug.**>
+  @type stdout
+</match>


### PR DESCRIPTION
Creates a Heroku application which listens on HTTPS for Heroku HTTPS log
drains, injects attributes for hostname, service, and tag into the record,
and pushes those records to DataDog.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>