### PR TITLE
Loosen fluentd and datadog plugin deps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,6 @@ source 'http://rubygems.org'
 
 # ruby '>= 2.3.1', '< 2.6'
 
-gem 'fluentd', '~> 1.2.2'
-gem 'fluent-plugin-datadog', '~> 0.10.3'
+gem 'fluentd', '~> 1.2'
+gem 'fluent-plugin-datadog', '~> 0.10'
 gem 'fluent-plugin-heroku-http', '~> 0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,9 +34,9 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  fluent-plugin-datadog (~> 0.10.3)
+  fluent-plugin-datadog (~> 0.10)
   fluent-plugin-heroku-http (~> 0.0.1)
-  fluentd (~> 1.2.2)
+  fluentd (~> 1.2)
 
 BUNDLED WITH
-   1.16.1
+   1.17.2


### PR DESCRIPTION
Allow for use of newer versions of fluentd and the fluent-datadog-plugin
by reducing the dependency restrictions to major/minor versions.

Signed-off-by: Chris Gianelloni <cgianelloni@applause.com>